### PR TITLE
fix script to work with the two supported Desktop Environment

### DIFF
--- a/massos-upgrade
+++ b/massos-upgrade
@@ -38,6 +38,15 @@ elif [ -z "$1" ] && [ "$(cat /etc/massos-release)" = "development" ]; then
   fi
   unset choice
 fi
+# Define MassOS flavour
+if [ -e /usr/share/xsessions/xfce.desktop ]; then
+  flavour="xfce"
+elif [ -e /usr/share/wayland-sessions/gnome-wayland.desktop ]; then
+  flavour="gnome"
+else
+  echo "Desktop Environment not supported"
+  exit
+fi
 savedir="$PWD"
 rm -rf /var/tmp/upgrade2*
 wdir=/var/tmp/upgrade$(date "+%Y%m%d%H%M%S")
@@ -102,7 +111,7 @@ else
   fi
   unset choice
   echo "Downloading the upgrade. This may take a while..."
-  curl -L "https://github.com/MassOS-Linux/MassOS/releases/download/v$(cat $wdir/massos-release)/massos-$(cat $wdir/massos-release)-rootfs-x86_64.tar.xz" -o $wdir/massos-upgrade.tar.xz
+  curl -L "https://github.com/MassOS-Linux/MassOS/releases/download/v$(cat $wdir/massos-release)/massos-$(cat $wdir/massos-release)-rootfs-x86_64-$flavour.tar.xz" -o $wdir/massos-upgrade.tar.xz
   if [ $? -ne 0 ]; then
     echo "Error: Could not download the upgrade." >&2
     rm -rf $wdir


### PR DESCRIPTION
Simple change to allow massupgrade to work with simple upgrade (e.g. still not working when glibc is updated). This was broken since massos provide gnome and xfce.